### PR TITLE
Fix looking up 'XDG_CONFIG_HOME' envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # era
 
-v0.1.0  
+v0.1.0
 A rainy clock in your terminal, written with Deno.
 
 ![sample gif](screenshots/sample.gif)
@@ -23,7 +23,7 @@ make install
 ./era
 ```
 
-creates `config.json` in your `$XDG_CONFIG_HOME/era/` automatically and you have a rainy clock.  
+creates `config.json` in your `$XDG_CONFIG_HOME/era/` automatically and you have a rainy clock.
 Or,
 
 ```
@@ -44,6 +44,6 @@ To exit, press any key.
 {"interval":100,"frequency":40,"rain1":"│","rain2":" ","timecolor":"#eeeeee","raincolor":"#e0b0ff"}
 ```
 
-`interval` means how often the screen is updated (a.k.a how fast it rains). The bigger this number, The slower it rains.  
-The larger `frequency`, the fewer the raindrops.  
+`interval` means how often the screen is updated (a.k.a how fast it rains). The bigger this number, The slower it rains.
+The larger `frequency`, the fewer the raindrops.
 `rain1` and `rain2` are characters representing raindrops. By default `rain2` is just a whitespace, so raindrops are represented by rain1 (|) only. Of course you can change the shape of raindrops!

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ make install
 ```
 
 creates `config.json` in your `$XDG_CONFIG_HOME/era/` automatically and you have a rainy clock.
+
+NOTE: `era` assumes the value is `~/.config` if `$XDG_CONFIG_HOME` isn't defined as an environment variable.
+
 Or,
 
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ export const make_config = async () => {
   try {
     await Deno.stat(CONFIG_DIR);
   } catch (_error) {
-    await Deno.mkdir(CONFIG_DIR).catch();
+    await Deno.mkdir(CONFIG_DIR, { recursive: true }).catch();
   }
   await Deno.writeTextFile(CONFIG_PATH, JSON.stringify(config_example));
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
-const XDG = Deno.env.get("HOME");
-const CONFIG_DIR = XDG + "/.config/era";
+const XDG_CONFIG_HOME = Deno.env.get("XDG_CONFIG_HOME") || Deno.env.get("HOME") + "/.config";
+const CONFIG_DIR = XDG_CONFIG_HOME + "/era";
 export const CONFIG_PATH = CONFIG_DIR + "/config.json";
 
 export type Config = {


### PR DESCRIPTION
README says that 'era' lookups "$XDG_CONFIG_HOME" as a configuration directory, but it used to just lookup "$HOME/.config". I guess this doesn't make sense. So 'era' first lookups "$XDG_CONFIG_HOME", and if not found the variable, 'era' assumes the value is ~/.config/era now. This behavior probably is familiar in CLI application configurations.

And this patch fixes misc trivial stuffs.

Thank you for your cool CLI application.